### PR TITLE
Focus on the HTML portion of a svelte document

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
         "title": "Focus on Script (Svelte)"
       },
       {
+        "command": "svelte-tag-focuser.focusOnHTML",
+        "title": "Focus on HTML (Svelte)"
+      },
+      {
           "command": "svelte-tag-focuser.focusOnStyle",
           "title": "Focus on Style (Svelte)"
       }
@@ -42,6 +46,12 @@
         "command": "svelte-tag-focuser.focusOnScript",
         "key": "ctrl+shift+s",
         "mac": "cmd+shift+s",
+        "when": "editorTextFocus && editorLangId == svelte"
+      },
+      {
+        "command": "svelte-tag-focuser.focusOnHTML",
+        "key": "ctrl+shift+h",
+        "mac": "cmd+shift+h",
         "when": "editorTextFocus && editorLangId == svelte"
       },
       {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
         "title": "Focus on HTML (Svelte)"
       },
       {
-          "command": "svelte-tag-focuser.focusOnStyle",
-          "title": "Focus on Style (Svelte)"
+        "command": "svelte-tag-focuser.focusOnStyle",
+        "title": "Focus on Style (Svelte)"
       }
     ],
     "keybindings": [
@@ -55,12 +55,12 @@
         "when": "editorTextFocus && editorLangId == svelte"
       },
       {
-          "command":  "svelte-tag-focuser.focusOnStyle",
-          "key": "ctrl+shift+t",
-          "mac": "cmd+shift+t",
-          "when": "editorTextFocus && editorLangId == svelte"
+        "command": "svelte-tag-focuser.focusOnStyle",
+        "key": "ctrl+shift+t",
+        "mac": "cmd+shift+t",
+        "when": "editorTextFocus && editorLangId == svelte"
       }
-   ]
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-async function focusTag(editor: vscode.TextEditor, tagName: string): Promise<void> {
+async function focusTag(editor: vscode.TextEditor, tagName: string): Promise<void> { 
     const content = editor.document.getText();
     const tagRegex = new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)<\\/${tagName}>`, 'gi');
     const match = tagRegex.exec(content);
@@ -8,6 +8,18 @@ async function focusTag(editor: vscode.TextEditor, tagName: string): Promise<voi
         const startPosition = editor.document.positionAt(match.index);
         const endPosition = editor.document.positionAt(match.index + match[0].length);
         const range = new vscode.Range(startPosition, endPosition);
+        editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
+        editor.selection = new vscode.Selection(startPosition, startPosition);
+    }
+}
+
+async function focusHTML(editor: vscode.TextEditor): Promise<void> { 
+    const content = editor.document.getText();
+    const tagRegex = new RegExp(`<script[^>]*>([\\s\\S]*?)<\\/script>`, 'gi');
+    const match = tagRegex.exec(content);
+    if (match) {
+        const position = editor.document.positionAt(match.index + match[0].length);
+        const range = new vscode.Range(position, position);
         editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
         editor.selection = new vscode.Selection(startPosition, startPosition);
     }
@@ -23,6 +35,14 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    // Create a command to focus on the HTML
+    let htmlCommand = vscode.commands.registerCommand('svelte-tag-focuser.focusOnHTML', () => {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor) {
+            foucsHTML(activeEditor);
+        }
+    });
+
     // Create a command to focus on the style tag
     let styleCommand = vscode.commands.registerCommand('svelte-tag-focuser.focusOnStyle', () => {
         const activeEditor = vscode.window.activeTextEditor;
@@ -31,5 +51,5 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    context.subscriptions.push(scriptCommand, styleCommand);
+    context.subscriptions.push(scriptCommand, htmlCommand, styleCommand);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ async function focusHTML(editor: vscode.TextEditor): Promise<void> {
         const position = editor.document.positionAt(match.index + match[0].length);
         const range = new vscode.Range(position, position);
         editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
-        editor.selection = new vscode.Selection(startPosition, startPosition);
+        editor.selection = new vscode.Selection(position, position);
     }
 }
 
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
     let htmlCommand = vscode.commands.registerCommand('svelte-tag-focuser.focusOnHTML', () => {
         const activeEditor = vscode.window.activeTextEditor;
         if (activeEditor) {
-            foucsHTML(activeEditor);
+            focusHTML(activeEditor);
         }
     });
 


### PR DESCRIPTION
Jumps to the end of the script tags to show where the html would usually be